### PR TITLE
adjust helper lon by one pixel

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SHTnsSpheres"
 uuid = "9e5c175a-5132-4517-85a1-2957ec255f89"
-authors = ["The ClimFlows contributors"]
-version = "0.2.5-DEV"
+authors = ["Thomas Dubos, Zack Li"]
+version = "0.2.5"
 
 [deps]
 MutatingOrNot = "6a37069a-9a67-4b2d-a34a-f09ab4b23c7c"

--- a/src/SHTnsSpheres.jl
+++ b/src/SHTnsSpheres.jl
@@ -55,7 +55,7 @@ struct SHTnsSphere
         info = unsafe_load(ptr,1)
         costheta = [unsafe_load(info.ct, i) for i in 1:nlat]
         sintheta = [unsafe_load(info.st, i) for i in 1:nlat]
-        lon    = [ pi*j/nlat   for i=0:(nlat-1), j=1:2nlat] # longitudes
+        lon    = [ pi*j/nlat   for i=1:nlat, j=0:(2nlat-1) ] # longitudes
         coslat = [ sintheta[i] for i=1:nlat, j=1:2nlat]
         sinlat = [ costheta[i] for i=1:nlat, j=1:2nlat] # sin(lat)
         x   = @. cos(lon)*coslat

--- a/src/SHTnsSpheres.jl
+++ b/src/SHTnsSpheres.jl
@@ -55,7 +55,7 @@ struct SHTnsSphere
         info = unsafe_load(ptr,1)
         costheta = [unsafe_load(info.ct, i) for i in 1:nlat]
         sintheta = [unsafe_load(info.st, i) for i in 1:nlat]
-        lon    = [ pi*j/nlat   for i=1:nlat, j=1:2nlat] # longitudes
+        lon    = [ pi*j/nlat   for i=0:(nlat-1), j=1:2nlat] # longitudes
         coslat = [ sintheta[i] for i=1:nlat, j=1:2nlat]
         sinlat = [ costheta[i] for i=1:nlat, j=1:2nlat] # sin(lat)
         x   = @. cos(lon)*coslat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,10 +106,32 @@ function test_AD(sph, F=Float64)
 
 end
 
+
+
+#========= Check the phase of the spherical harmonics on one example =======#
+
+function Y11(x,y,z,lon,lat)
+    θ = π/2 - lat
+    ϕ = lon
+    return -sqrt(3/(2π)) * real(exp(1im * ϕ)) * sin(θ)
+end
+
+function test_azimuthal_phase(sph)
+    xy_spat = sample_scalar!(void, Y11, sph) 
+    xy_spec = analysis_scalar!(void, xy_spat, sph)
+    l, m = 1, 1
+    LM = (m * (2 * sph.lmax + 2 - (m + 1))) >> 1 + l + 1
+    result = xy_spec[LM]
+    @test real(result) ≈ 1.0
+    @test imag(result) ≈ 0.0 atol=eps()
+end
+
+
 nlat = 128
 sph = SHTnsSphere(nlat)
 @show sph
 @testset "synthesis∘analysis == identity" test_inv(sph)
 @testset "Autodiff for SHTns" test_AD(sph)
+@testset "azimuthal phase aligned with coordinates" test_azimuthal_phase(sph)
 
 include("scaling.jl")

--- a/test/scaling.jl
+++ b/test/scaling.jl
@@ -21,7 +21,7 @@ function scaling(fun, name, sph, N)
         nt==1 && (single=elapsed)
         speedup = single/elapsed
         percent(x) = round(100x; digits=0)
-        @info "$nt \t\t $(round(elapsed; digits=4)) \t\t $(percent(speedup)) \t\t $(percent(speedup/nt))" 
+        @info "$nt \t\t $(round(elapsed; digits=4)) \t $(percent(speedup)) \t\t $(percent(speedup/nt))" 
     end
 end
 

--- a/test/scaling.jl
+++ b/test/scaling.jl
@@ -21,7 +21,7 @@ function scaling(fun, name, sph, N)
         nt==1 && (single=elapsed)
         speedup = single/elapsed
         percent(x) = round(100x; digits=0)
-        @info "$nt \t\t $(round(elapsed; digits=4)) \t $(percent(speedup)) \t $(percent(speedup/nt))" 
+        @info "$nt \t\t $(round(elapsed; digits=4)) \t\t $(percent(speedup)) \t\t $(percent(speedup/nt))" 
     end
 end
 


### PR DESCRIPTION
I found your package to be a very convenient wrapper for testing out SHTns on a Gauss grid. However, I believe there is a small phase difference in the $\phi$ convenience array, as SHTns uses a convention where the first pixel [starts at 0](https://www2.atmos.umd.edu/~dkleist/docs/shtns/doc/html/spat.html). 

This difference results in a phase difference of $2\pi / n_{lat}$ on the spherical harmonic coefficients. I imagine this is not desirable, since you will see the typical real harmonics have a small complex rotation.

```julia
using SHTnsSpheres: SHTnsSphere, sample_scalar!, analysis_scalar!, void

function Y11(x,y,z,lon,lat)
    θ = π/2 - lat
    ϕ = lon
    return sqrt(3/(2π)) * real(exp(1im * ϕ)) * sin(θ)
end

sphere = SHTnsSphere(21, 1)
xy_spat = sample_scalar!(void, Y11, sphere) 
xy_spec = analysis_scalar!(void, xy_spat, sphere)

xy_spec[16]  # -0.9888308262251284 - 0.1490422661761743im
```