### PR TITLE
Hotfix/analysis scalar

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SHTnsSpheres"
 uuid = "9e5c175a-5132-4517-85a1-2957ec255f89"
 authors = ["Thomas Dubos, Zack Li"]
-version = "0.2.6"
+version = "0.2.7"
 
 [deps]
 MutatingOrNot = "6a37069a-9a67-4b2d-a34a-f09ab4b23c7c"

--- a/src/SHTnsSpheres.jl
+++ b/src/SHTnsSpheres.jl
@@ -90,7 +90,7 @@ struct SHTnsSphere
                    sph.x, sph.y, sph.z, sph.lon, sph.lat,
                    sph.laplace, sph.poisson)
     end
-    
+
 end
 
 Base.show(io::IO, sph::SHTnsSphere) =
@@ -205,7 +205,7 @@ synthesis_scalar!(spat::Array{Float64}, spec::Array{ComplexF64}, sph::SHTnsSpher
 synthesis_scalar!(::Void, spec, sph) = synthesis_scalar!(similar_spat(spec, sph), spec, sph)
 
 analysis_scalar!(spec::Array{ComplexF64}, spat::Array{Float64}, sph::SHTnsSphere) =
-    analysis!(priv.spat_to_SH, sph, spec, spat)
+    analysis!(priv.spat_to_SH, sph, spec, writable(spat))
 
 analysis_scalar!(::Void, spat::AF64, sph::SHTnsSphere) = analysis_scalar!(similar_spec(spat, sph), spat, sph)
 

--- a/src/SHTnsSpheres.jl
+++ b/src/SHTnsSpheres.jl
@@ -204,10 +204,10 @@ synthesis_scalar!(spat::Array{Float64}, spec::Array{ComplexF64}, sph::SHTnsSpher
 
 synthesis_scalar!(::Void, spec, sph) = synthesis_scalar!(similar_spat(spec, sph), spec, sph)
 
-analysis_scalar!(spec::Array{ComplexF64}, spat::Array{Float64}, sph::SHTnsSphere) =
+analysis_scalar!(spec::Array{ComplexF64}, spat::In{<:Array{Float64}}, sph::SHTnsSphere) =
     analysis!(priv.spat_to_SH, sph, spec, writable(spat))
 
-analysis_scalar!(::Void, spat::AF64, sph::SHTnsSphere) = analysis_scalar!(similar_spec(spat, sph), spat, sph)
+analysis_scalar!(::Void, spat::In{<:Array{Float64}}, sph::SHTnsSphere) = analysis_scalar!(similar_spec(spat, sph), spat, sph)
 
 #========= vector synthesis / analysis ========#
 


### PR DESCRIPTION
`analysis_scalar!` can overwrite the spatial input field `spat`, leading to hard-to-find bugs.
Now a copy is made, unless it is passed as `erase(spat)`.